### PR TITLE
Implement Enums

### DIFF
--- a/.github/workflows/build-database-release.yml
+++ b/.github/workflows/build-database-release.yml
@@ -41,4 +41,4 @@ jobs:
         generate_release_notes: true
         files: |
           dpm-sqlite.zip
-          dpm_models.py
+          *.py

--- a/.github/workflows/build-database.yml
+++ b/.github/workflows/build-database.yml
@@ -73,21 +73,13 @@ jobs:
       run: |
         opendpm convert ${{ env.INPUT_DIR }} ${{ env.OUTPUT_DIR_SQLITE }}
         
-    - name: Generate models from SQLite
-      shell: bash
-      run: |
-        pip install sqlacodegen
-        DB_PATH="${{ env.OUTPUT_DIR_SQLITE }}/dpm.sqlite"
-        echo "Generating models from $DB_PATH"
-        sqlacodegen "sqlite:///$DB_PATH" --outfile ${{ env.OUTPUT_DIR_SQLITE }}/dpm_models.py --options nojoined
-
     - name: Format generated models with ruff
       shell: bash
       run: |
         pip install ruff
         echo "Formatting generated model file with ruff"
-        ruff check --fix-only ${{ env.OUTPUT_DIR_SQLITE }}/dpm_models.py
-        ruff format ${{ env.OUTPUT_DIR_SQLITE }}/dpm_models.py
+        ruff check --fix-only ${{ env.OUTPUT_DIR_SQLITE }}/*.py
+        ruff format ${{ env.OUTPUT_DIR_SQLITE }}/*.py
 
     - name: Upload SQLite database artifact
       uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "sqlalchemy>=2.0.25",
     "sqlalchemy-access>=2.0.0",
     "requests>=2.32.3",
+    "sqlacodegen>=3.0.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/src/opendpm/cli.py
+++ b/src/opendpm/cli.py
@@ -47,7 +47,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     convert_parser.add_argument(
         "output_dir",
+        nargs="?",
         type=Path,
+        default=Path.cwd(),
         help="Directory to save converted databases",
     )
 

--- a/src/opendpm/convert/generation.py
+++ b/src/opendpm/convert/generation.py
@@ -1,0 +1,17 @@
+"""Model generation utilities."""
+
+from sqlacodegen.generators import DeclarativeGenerator
+from sqlalchemy import Engine, MetaData
+
+
+def generate_models(metadata: MetaData, engine: Engine) -> str:
+    """Generate SQLAlchemy models from database metadata."""
+    generator = DeclarativeGenerator(
+        metadata,
+        engine,
+        ["use_inflect", "nojoined", "nobidi"],
+        indentation="    ",
+        base_class_name="Base",
+    )
+
+    return generator.generate()

--- a/src/opendpm/convert/generation.py
+++ b/src/opendpm/convert/generation.py
@@ -1,17 +1,201 @@
-"""Model generation utilities."""
+"""Model generator for generating SQLAlchemy models from database metadata."""
 
-from sqlacodegen.generators import DeclarativeGenerator
-from sqlalchemy import Engine, MetaData
+from collections import defaultdict
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    Column,
+    Enum,
+    MetaData,
+    Table,
+)
+
+indent = "    "
+
+type Imports = dict[str, set[str]]
 
 
-def generate_models(metadata: MetaData, engine: Engine) -> str:
-    """Generate SQLAlchemy models from database metadata."""
-    generator = DeclarativeGenerator(
-        metadata,
-        engine,
-        ["use_inflect", "nojoined", "nobidi"],
-        indentation="    ",
-        base_class_name="Base",
-    )
+class ModelGenerator:
+    """Custom generator for SQLAlchemy models."""
 
-    return generator.generate()
+    def __init__(self, metadata: MetaData) -> None:
+        """Initialize the model generator."""
+        self.metadata = metadata
+        self.imports: Imports = defaultdict(set)
+
+    def generate(self) -> str:
+        """Generate SQLAlchemy models from database metadata."""
+        self.imports["__future__"].add("annotations")
+
+        # Generate model code
+        models: list[str] = []
+        for _, table in sorted(self.metadata.tables.items()):
+            models.append(self.generate_model(table))
+
+        # Combine everything into a single file
+        return self._render_file(models)
+
+    def generate_model(self, table: Table) -> str:
+        """Generate a SQLAlchemy model for a table."""
+        # Generate class definition
+        lines = [f"class {table.name}(Base):"]
+
+        # Add __tablename__ attribute
+        lines.append(f'{indent}__tablename__ = "{table.name}"')
+
+        # Add columns
+        lines.extend([self._generate_column(column) for column in table.columns])
+
+        # Add relationships
+        lines.extend(self._generate_relationships(table))
+
+        return "\n".join(lines)
+
+    def _generate_imports(self) -> str:
+        """Generate import statements."""
+        return "\n".join(
+            f"from {module} import {', '.join(sorted(names))}"
+            if names
+            else f"import {module}"
+            for module, names in self.imports.items()
+        )
+
+    def _generate_base_class(self) -> str:
+        """Generate the base class definition."""
+        self.imports["sqlalchemy.orm"].add("DeclarativeBase")
+        return f'class Base(DeclarativeBase):\n{indent}"""Base class for all models."""'
+
+    def _generate_column[T](self, column: Column[T]) -> str:
+        """Generate SQLAlchemy column definition."""
+        # Determine Python type for the column
+        python_type = self._get_python_type(column)
+
+        # Process column attributes
+        kwargs = self._process_column_key_attributes(column)
+        args = self._process_column_foreign_keys(column)
+
+        # Format kwargs
+        kwargs_str = ", ".join(f"{k}={v}" for k, v in kwargs.items())
+        args_str = ", ".join(args)
+
+        # Combine args and kwargs
+        combined_args = ", ".join(filter(None, [args_str, kwargs_str]))
+
+        self.imports["sqlalchemy.orm"].add("Mapped")
+        declaration = f"{indent}{column.name}: Mapped[{python_type}]"
+
+        # Generate the column definition
+        if combined_args:
+            self.imports["sqlalchemy.orm"].add("mapped_column")
+            return f"{declaration} = mapped_column({combined_args})"
+
+        return declaration
+
+    def _process_column_key_attributes(self, column: Column[Any]) -> dict[str, Any]:
+        """Process primary key attributes of a column."""
+        kwargs: dict[str, Any] = {}
+        if column.primary_key:
+            kwargs["primary_key"] = True
+
+        return kwargs
+
+    def _process_column_foreign_keys(self, column: Column[Any]) -> list[str]:
+        """Process foreign keys of a column."""
+        foreign_keys: list[str] = []
+        for fk in column.foreign_keys:
+            ref_table = fk.column.table.name
+            ref_column = fk.column.name
+            self.imports["sqlalchemy"].add("ForeignKey")
+            foreign_keys.append(f'ForeignKey("{ref_table}.{ref_column}")')
+
+        return foreign_keys
+
+    def _generate_relationships(self, table: Table) -> list[str]:
+        """Generate SQLAlchemy relationship definitions."""
+        relationships: list[str] = []
+
+        # Find foreign keys that reference this table
+        for ref_table_name, ref_table in self.metadata.tables.items():
+            for column in ref_table.columns:
+                for fk in column.foreign_keys:
+                    if fk.column.table == table:
+                        rel_def = self._create_relationship_definition(
+                            table,
+                            ref_table_name,
+                            column,
+                        )
+                        relationships.append(rel_def)
+
+        return relationships
+
+    def _create_relationship_definition(
+        self,
+        table: Table,
+        ref_table_name: str,
+        column: Column[Any],
+    ) -> str:
+        """Create a relationship definition."""
+        ref_name = self._to_relationship_name(ref_table_name)
+        backref_name = self._to_relationship_name(table.name)
+
+        # Determine if it's a one-to-many or many-to-one relationship
+        if column.primary_key:
+            # One-to-one relationship
+            rel_type = f"{ref_table_name} | None"
+        else:
+            # One-to-many relationship
+            rel_type = f"list[{ref_table_name}]"
+
+        self.imports["sqlalchemy.orm"].update(("Mapped", "relationship"))
+        return (
+            f"{indent}{ref_name}: Mapped[{rel_type}]"
+            f'= relationship("{ref_table_name}", back_populates="{backref_name}")'
+        )
+
+    def _get_python_type(self, column: Column[Any]) -> str:
+        """Get Python type for a column."""
+        col_type = column.type
+
+        python_type = col_type.python_type
+        python_type_name = python_type.__name__
+
+        if python_type == date:
+            self.imports["datetime"].add("date")
+        elif python_type == datetime:
+            self.imports["datetime"].add("datetime")
+        elif python_type == Decimal:
+            self.imports["decimal"].add("Decimal")
+        elif isinstance(col_type, Enum):
+            # Handle Enum types
+            self.imports["typing"].add("Literal")
+            enums = [f'"{enum}"' for enum in col_type.enums]  # type: ignore unknown
+            python_type_name = f"Literal[{', '.join(enums)}]"
+
+        # Handle nullable columns
+        if column.nullable:
+            python_type_name = f"{python_type_name} | None"
+
+        return python_type_name
+
+    def _to_relationship_name(self, table_name: str) -> str:
+        """Convert table name to relationship name."""
+        if table_name.endswith("VID"):
+            table_name = table_name.removesuffix("VID")
+            table_name += "Version"
+
+        if table_name.endswith("ID"):
+            table_name = table_name.removesuffix("ID")
+
+        return table_name
+
+    def _render_file(self, models: list[str]) -> str:
+        """Render the complete model file."""
+        # Generate file header
+        base_class = self._generate_base_class()
+        imports = self._generate_imports()
+        header = ['"""SQLAlchemy models generated from DPM."""', imports, base_class]
+
+        # Combine header and models
+        return "\n".join(header + models)

--- a/src/opendpm/convert/main.py
+++ b/src/opendpm/convert/main.py
@@ -35,7 +35,13 @@ def migrate_database(input_dir: str | Path, output_dir: str | Path) -> None:
 
     start_time = time.time()
 
-    for access_file in access_files:
-        process_database(access_file, target_engine)
+    models = {
+        i: process_database(access_file, target_engine)
+        for i, access_file in enumerate(access_files)
+    }
+
+    for i, model in models.items():
+        with (output_dir / f"{i}_dpm_model.py").open("w") as f:
+            f.write(model)
 
     logger.info("Migrated databases in %s", format_time(time.time() - start_time))

--- a/src/opendpm/convert/utils.py
+++ b/src/opendpm/convert/utils.py
@@ -9,9 +9,13 @@ DAY = 24 * HOUR
 def format_time(seconds: float) -> str:
     """Format time in seconds to a human-readable string."""
     if seconds < MINUTE:
-        return f"{seconds:.2f} seconds"
+        return f"{seconds:.0f} seconds"
     if seconds < HOUR:
-        return f"{seconds / MINUTE:.2f} minutes"
+        minutes, seconds = divmod(seconds, MINUTE)
+        return f"{minutes:.0f} minutes and {seconds:.0f} seconds"
     if seconds < DAY:
-        return f"{seconds / HOUR:.2f} hours"
-    return f"{seconds / DAY:.2f} days"
+        hours, minutes = divmod(seconds, HOUR)
+        return f"{hours:.0f} hours and {minutes:.0f} minutes"
+
+    days, hours = divmod(seconds, DAY)
+    return f"{days:.0f} days and {hours:.0f} hours"

--- a/src/opendpm/sources.toml
+++ b/src/opendpm/sources.toml
@@ -1,4 +1,4 @@
 # Configuration for source Access database files
 # Format: version = "url"
 
-"4.0" = "https://www.eba.europa.eu/sites/default/files/2024-12/11b02b99-1486-4a54-815d-289558589773/dpm_2.0_release_4.0.zip"
+"4.0.0" = "https://www.eba.europa.eu/sites/default/files/2024-12/11b02b99-1486-4a54-815d-289558589773/dpm_2.0_release_4.0.zip"

--- a/uv.lock
+++ b/uv.lock
@@ -89,12 +89,35 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197 },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3b/7fa1fe835e2e93fd6d7b52b2f95ae810cf5ba133e1845f726f5a992d62c2/more-itertools-10.6.0.tar.gz", hash = "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b", size = 125009 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/62/0fe302c6d1be1c777cab0616e6302478251dfbf9055ad426f5d0def75c89/more_itertools-10.6.0-py3-none-any.whl", hash = "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89", size = 63038 },
+]
+
+[[package]]
 name = "opendpm"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyodbc" },
     { name = "requests" },
+    { name = "sqlacodegen" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-access" },
 ]
@@ -103,6 +126,7 @@ dependencies = [
 requires-dist = [
     { name = "pyodbc", specifier = ">=5.1.0" },
     { name = "requests", specifier = ">=2.32.3" },
+    { name = "sqlacodegen", specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.25" },
     { name = "sqlalchemy-access", specifier = ">=2.0.0" },
 ]
@@ -156,6 +180,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlacodegen"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "inflect" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ed/633a47383bc1640ae94625b9df1e6f7f461644c0c539c7e69c7654ab1239/sqlacodegen-3.0.0.tar.gz", hash = "sha256:785bc9307b787a9ae7ffc1460abf0a718862b6fa47f304259503612298e523f2", size = 39182 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/6a/0398fa0ab13142d8836258814dc6069c57f459afa5adfd60859e8657fd6a/sqlacodegen-3.0.0-py3-none-any.whl", hash = "sha256:ce3042fff03ceb0426cdfb7237a4a13781166718ae22b63156e5f4b3232137e4", size = 21661 },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.37"
 source = { registry = "https://pypi.org/simple" }
@@ -196,6 +233,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/e3/02801e7b150342be8b7146227beb7943723511eb2f074bb836eae05e7578/sqlalchemy_access-2.0.3.tar.gz", hash = "sha256:89174a94e0ebd6c32470282d143aef0c0fbe3aafdee2c40956cd417648cb317e", size = 18011 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/7a/3b1e307688795342f977d54b6f9d56665860455663859bd459ee117f7179/sqlalchemy_access-2.0.3-py3-none-any.whl", hash = "sha256:e50dba5cbf346ad1599ee87ff83260f70c39b555b0277bc63321fefa7f022e48", size = 13980 },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/60/8cd6a3d78d00ceeb2193c02b7ed08f063d5341ccdfb24df88e61f383048e/typeguard-4.4.2.tar.gz", hash = "sha256:a6f1065813e32ef365bc3b3f503af8a96f9dd4e0033a02c28c4a4983de8c6c49", size = 75746 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/4b/9a77dc721aa0b7f74440a42e4ef6f9a4fae7324e17f64f88b96f4c25cc05/typeguard-4.4.2-py3-none-any.whl", hash = "sha256:77a78f11f09777aeae7fa08585f33b5f4ef0e7335af40005b0c422ed398ff48c", size = 35801 },
 ]
 
 [[package]]


### PR DESCRIPTION
In order to provide the best possible experience when using the DPM SQLite database, we want to provide a detailed SQLAlchemy declarative model. Since manually defining the model is out of scope we dynamically generate it using SQLAcodegen. SQLite does not natively support Enums, however SQLA has dialect support for it. As such we are able to create a SQLA model with Enums giving the users the best possible experience. To do this we have to dynamically analyse the DPM to determine potential Enums and subclass the SQLAcodegen generator to correctly implement the enum support.