### PR TITLE
fix(workflows): resolve artifact name mismatch in database comparison

### DIFF
--- a/.github/workflows/build-database.yml
+++ b/.github/workflows/build-database.yml
@@ -39,4 +39,5 @@ jobs:
     uses: ./.github/workflows/compare-previous.yml
     with:
       version_id: ${{ inputs.version_id }}
+      current_database_artifact_name: ${{ needs.migrate.outputs.artifact_name }}
       output_format: "html"

--- a/.github/workflows/compare-previous.yml
+++ b/.github/workflows/compare-previous.yml
@@ -7,6 +7,10 @@ on:
         description: "The version ID to compare against its predecessor"
         required: true
         type: string
+      current_database_artifact_name:
+        description: "Name of artifact containing the current version's SQLite database"
+        required: true
+        type: string
       output_format:
         description: "Output format for comparison"
         required: false
@@ -85,7 +89,7 @@ jobs:
       - name: Download current database artifact
         uses: actions/download-artifact@v6
         with:
-          name: ${{ inputs.version_id }}-original-sqlite
+          name: ${{ inputs.current_database_artifact_name }}
           path: ./new-db/
 
       - name: Find database files


### PR DESCRIPTION
The compare-previous workflow was trying to download an artifact named
'{version_id}-original-sqlite', but the actual artifact created by the
migration workflow was '{version_id}-archive-sqlite'.

This fix:
- Adds 'current_database_artifact_name' input parameter to compare-previous.yml
- Passes the actual artifact name from migrate job in build-database.yml
- Removes hardcoded artifact name assumptions for better maintainability

This ensures the comparison workflow correctly downloads the migrated
database artifact regardless of the source database type.