### PR TITLE
claude/fix-dpm2-artifact-duplicates-rmsSH

### DIFF
--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -33,13 +33,47 @@ jobs:
         run: |
           echo version_ids={\"includes\":$(uv run dpm-toolkit versions --fmt json | jq 'map(.id)')} >> $GITHUB_OUTPUT
 
-  build-versions:
+  build-database:
     needs: list-versions
     strategy:
       matrix: ${{ fromJson(needs.list-versions.outputs.version_ids) }}
       # Allow other versions to build even if one fails
       fail-fast: false
-
     uses: ./.github/workflows/build-database.yml
     with:
       version_id: ${{ matrix.includes }}
+
+  # Downstream matrixed jobs reconstruct artifact names from matrix.includes
+  # because GitHub Actions cannot pass per-matrix-iteration outputs between
+  # reusable-workflow jobs. The naming scheme here matches the outputs of
+  # build-database.yml (which chains download -> migrate -> schema).
+  build-dpm2:
+    needs: [list-versions, build-database]
+    strategy:
+      matrix: ${{ fromJson(needs.list-versions.outputs.version_ids) }}
+      fail-fast: false
+    uses: ./.github/workflows/build-dpm2.yml
+    with:
+      sqlite_artifact_name: ${{ matrix.includes }}-archive-sqlite
+      schema_artifact_name: ${{ matrix.includes }}-archive-sqlite-schema
+
+  analyze:
+    needs: [list-versions, build-database]
+    strategy:
+      matrix: ${{ fromJson(needs.list-versions.outputs.version_ids) }}
+      fail-fast: false
+    uses: ./.github/workflows/analyze-database.yml
+    with:
+      sqlite_artifact_name: ${{ matrix.includes }}-archive-sqlite
+      confidence_threshold: "0.8"
+
+  compare:
+    needs: [list-versions, build-database]
+    strategy:
+      matrix: ${{ fromJson(needs.list-versions.outputs.version_ids) }}
+      fail-fast: false
+    uses: ./.github/workflows/compare-previous.yml
+    with:
+      version_id: ${{ matrix.includes }}
+      current_database_artifact_name: ${{ matrix.includes }}-archive-sqlite
+      output_format: "html"

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -1,11 +1,17 @@
 name: Build All Database Versions
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]
   pull_request:
     branches: [main]
   workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
 
 jobs:
   list-versions:

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -10,9 +10,6 @@ on:
     branches: [main]
   workflow_dispatch: # Allow manual trigger
 
-permissions:
-  contents: read
-
 jobs:
   list-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-database.yml
+++ b/.github/workflows/build-database.yml
@@ -7,21 +7,6 @@ on:
         description: "The version ID to build."
         required: true
         type: string
-      include_analyze:
-        description: "Whether to run type refinement analysis."
-        required: false
-        type: boolean
-        default: true
-      include_compare:
-        description: "Whether to run comparison with previous version."
-        required: false
-        type: boolean
-        default: true
-      include_build_dpm2:
-        description: "Whether to build (and test) the dpm2 wheel."
-        required: false
-        type: boolean
-        default: true
     outputs:
       database_artifact_name:
         description: "The name of the uploaded artifact containing the SQLite database"
@@ -29,12 +14,6 @@ on:
       schema_artifact_name:
         description: "The name of the uploaded artifact containing the generated schema"
         value: ${{ jobs.schema.outputs.artifact_name }}
-      wheel_artifact_name:
-        description: "The name of the uploaded artifact containing the built dpm2 wheel"
-        value: ${{ jobs.build-dpm2.outputs.wheel_artifact_name }}
-      analysis_artifact_name:
-        description: "The name of the uploaded artifact containing the type analysis reports"
-        value: ${{ jobs.analyze.outputs.artifact_name }}
 
 jobs:
   download:
@@ -54,28 +33,3 @@ jobs:
     uses: ./.github/workflows/generate-schema.yml
     with:
       sqlite_artifact_name: ${{ needs.migrate.outputs.artifact_name }}
-
-  build-dpm2:
-    if: ${{ inputs.include_build_dpm2 }}
-    needs: [migrate, schema]
-    uses: ./.github/workflows/build-dpm2.yml
-    with:
-      sqlite_artifact_name: ${{ needs.migrate.outputs.artifact_name }}
-      schema_artifact_name: ${{ needs.schema.outputs.artifact_name }}
-
-  analyze:
-    if: ${{ inputs.include_analyze }}
-    needs: migrate
-    uses: ./.github/workflows/analyze-database.yml
-    with:
-      sqlite_artifact_name: ${{ needs.migrate.outputs.artifact_name }}
-      confidence_threshold: "0.8"
-
-  compare:
-    if: ${{ inputs.include_compare }}
-    needs: migrate
-    uses: ./.github/workflows/compare-previous.yml
-    with:
-      version_id: ${{ inputs.version_id }}
-      current_database_artifact_name: ${{ needs.migrate.outputs.artifact_name }}
-      output_format: "html"

--- a/.github/workflows/build-database.yml
+++ b/.github/workflows/build-database.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: true
+      include_build_dpm2:
+        description: "Whether to build (and test) the dpm2 wheel."
+        required: false
+        type: boolean
+        default: true
     outputs:
       database_artifact_name:
         description: "The name of the uploaded artifact containing the SQLite database"
@@ -51,6 +56,7 @@ jobs:
       sqlite_artifact_name: ${{ needs.migrate.outputs.artifact_name }}
 
   build-dpm2:
+    if: ${{ inputs.include_build_dpm2 }}
     needs: [migrate, schema]
     uses: ./.github/workflows/build-dpm2.yml
     with:

--- a/.github/workflows/publish-dpm2.yml
+++ b/.github/workflows/publish-dpm2.yml
@@ -10,6 +10,7 @@ jobs:
       version_id: "release"
       include_analyze: false
       include_compare: false
+      include_build_dpm2: false
 
   version:
     needs: build-database

--- a/.github/workflows/publish-dpm2.yml
+++ b/.github/workflows/publish-dpm2.yml
@@ -8,9 +8,6 @@ jobs:
     uses: ./.github/workflows/build-database.yml
     with:
       version_id: "release"
-      include_analyze: false
-      include_compare: false
-      include_build_dpm2: false
 
   version:
     needs: build-database

--- a/.github/workflows/update-dpm2-models.yml
+++ b/.github/workflows/update-dpm2-models.yml
@@ -10,11 +10,16 @@ jobs:
     uses: ./.github/workflows/build-database.yml
     with:
       version_id: "release"
-      include_analyze: false
-      include_compare: false
+
+  build-dpm2:
+    needs: build-database
+    uses: ./.github/workflows/build-dpm2.yml
+    with:
+      sqlite_artifact_name: ${{ needs.build-database.outputs.database_artifact_name }}
+      schema_artifact_name: ${{ needs.build-database.outputs.schema_artifact_name }}
 
   update-models:
-    needs: build-database
+    needs: [build-database, build-dpm2]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The publish-dpm2 workflow was uploading two wheel artifacts with the
same name: one from build-database's internal build-dpm2 job and another
from its own versioned build-versioned job. Add an include_build_dpm2
input to build-database.yml (mirroring include_analyze/include_compare)
and set it false from publish-dpm2 so only the versioned wheel is built.