### PR TITLE
Add 4.3-draft to version archive

### DIFF
--- a/projects/archive/src/archive/versions.toml
+++ b/projects/archive/src/archive/versions.toml
@@ -145,3 +145,12 @@ revision = 1
 original = { url = "https://www.eba.europa.eu/sites/default/files/2026-02/ad0d2577-a1eb-4826-a249-a1f7701c6796/DPM2%20Database_v_4_2_1.zip", checksum = "sha256:0d1c0e608c98f01dc338a98e8e5f700c0fa2a2437cbef724fb8fc52618b4b74d" }
 archive = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.2-errata-1/dpm-4.2-errata-1-archive.zip", checksum = "sha256:400f534ef8e98d8af290c0e19bc3fc57ae7ed1418e91a0a2a58d4a23842c7493" }
 converted = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.2-errata-1/dpm-4.2-errata-1-sqlite.zip", checksum = "sha256:8448571bb6463147cee03809b70086d4ebbffa36ca433be4858332750ef3619d" }
+
+[[versions]]
+id = "4.3-draft"
+previous = "4.2-errata-1"
+version = "4.3"
+type = "draft"
+semver = "4.3.0-beta.1"
+date = 2026-04-16
+original = { url = "https://www.eba.europa.eu/sites/default/files/2026-04/a0cbe984-bb81-4546-bb27-a1cb87b8603a/DPM2%20Database_v4.3_draft.accdb_.zip", checksum = "sha256:edb25fb5273c4a4728028c33ec542fadbdb12bcc9b764ba22e067fdd022325ba" }


### PR DESCRIPTION
Register the DPM 2.0 release 4.3 draft published by the EBA on
2026-04-16. Only the original source is populated; the archive and
converted sources will be added once the db-4.3-draft GitHub release
is built. SHA256 checksum was computed locally against the downloaded
file.

https://claude.ai/code/session_01Rhm4qJx2LkSTCGh3VxqFRm