### PR TITLE
Add automatic foreign key healing for DPM schema models

### DIFF
--- a/projects/dpm2/src/dpm2/models.py
+++ b/projects/dpm2/src/dpm2/models.py
@@ -58,24 +58,6 @@ class AuxCellMapping(DPM):
     old_table_vid: Mapped[int] = mapped_column("OldTableVID")
 
 
-class AuxCellStatus(DPM):
-    """Auto-generated model for the Aux_CellStatus table."""
-
-    __tablename__ = "Aux_CellStatus"
-
-    table_vid: Mapped[int] = mapped_column("TableVID", primary_key=True)
-    cell_id: Mapped[int] = mapped_column("CellID", primary_key=True)
-    status: Mapped[
-        Literal[
-            "New variable",
-            "New variable version",
-            "Not reportable",
-            "Previous variable version",
-        ]
-    ] = mapped_column("Status")
-    is_new_cell: Mapped[bool] = mapped_column("IsNewCell")
-
-
 class Concept(DPM):
     """Auto-generated model for the Concept table."""
 
@@ -133,39 +115,6 @@ class Language(DPM):
 
     name: Mapped[str] = mapped_column("Name")
     language_code: Mapped[int] = mapped_column("LanguageCode", primary_key=True)
-
-
-ModelViolations = AlchemyTable(
-    "ModelViolations",
-    DPM.metadata,
-    Column("ViolationCode", String(255), nullable=False),
-    Column("Violation", String(255), nullable=False),
-    Column("isBlocking", Boolean, nullable=False),
-    Column("TableVID", Integer, nullable=False),
-    Column("OldTableVID", Integer, nullable=False),
-    Column("TableCode", String(255), nullable=False),
-    Column("HeaderID", Integer, nullable=False),
-    Column("HeaderCode", String(255), nullable=False),
-    Column("HeaderVID", Integer, nullable=False),
-    Column("OldHeaderVID", Integer, nullable=False),
-    Column("KeyHeader", Integer, nullable=False),
-    Column("HeaderDirection", String(255), nullable=False),
-    Column("HeaderPropertyID", Integer, nullable=False),
-    Column("HeaderPropertyCode", String(255), nullable=False),
-    Column("HeaderSubcategoryID", Integer, nullable=False),
-    Column("HeaderSubcategoryName", String(255), nullable=False),
-    Column("HeaderContextID", Integer, nullable=False),
-    Column("CategoryID", Integer, nullable=False),
-    Column("CategoryCode", String(255), nullable=False),
-    Column("ItemID", Integer, nullable=False),
-    Column("ItemCode", String(255), nullable=False),
-    Column("CellID", Integer, nullable=False),
-    Column("CellCode", String(255), nullable=False),
-    Column("Cell2ID", Integer, nullable=False),
-    Column("Cell2Code", String(255), nullable=False),
-    Column("VVEndReleaseID", Integer, nullable=False),
-    Column("NewAspect", String(255), nullable=False),
-)
 
 
 class Operator(DPM):
@@ -229,33 +178,6 @@ class SubdivisionType(DPM):
     )
 
 
-VarGenerationDetail = AlchemyTable(
-    "VarGeneration_Detail",
-    DPM.metadata,
-    Column("noofcells", Integer, nullable=False),
-    Column("NewAspect", String(255), nullable=False),
-    Column("ModuleVID", Integer, nullable=False),
-    Column("ModuleCode", String(255), nullable=False),
-    Column("TableCode", String(255), nullable=False),
-    Column("TableVID", Integer, nullable=False),
-    Column("CellID", Integer, nullable=False),
-    Column("cellcode", String(255), nullable=False),
-    Column("outcomeID", String(255), nullable=False),
-    Column("outcomeVID", String(255), nullable=False),
-    Column("ReportMsg", String(255), nullable=False),
-    Column("isVoid", Boolean, nullable=False),
-    Column("tvstartReleaseID", Integer, nullable=False),
-    Column("mvStartReleaseID", Integer, nullable=False),
-    Column("vvOldEndReleaseID", Integer, nullable=True),
-    Column("OldAspect", String(255), nullable=False),
-    Column("IsNewCell", Boolean, nullable=False),
-    Column("isnewPropertyDataType", Boolean, nullable=False),
-    Column("isNewKey", Boolean, nullable=False),
-    Column("OldVariableID", Integer, nullable=True),
-    Column("NewVarID", Integer, nullable=False),
-    Column("OldVariableVID", Integer, nullable=True),
-    Column("NewVVID", Integer, nullable=False),
-)
 VarGenerationSummary = AlchemyTable(
     "VarGeneration_Summary",
     DPM.metadata,
@@ -439,47 +361,6 @@ class OperatorArgument(DPM):
     argument_id: Mapped[int] = mapped_column("ArgumentID", primary_key=True)
 
     operator: Mapped[Operator] = relationship(foreign_keys=operator_id)
-
-
-class PSCurrentItemCategory(DPM):
-    """Auto-generated model for the PSCurrentItemCategory table."""
-
-    __tablename__ = "PSCurrentItemCategory"
-
-    item_id: Mapped[int] = mapped_column("ItemID")
-    start_release_id: Mapped[int] = mapped_column("StartReleaseID")
-    category_id: Mapped[int] = mapped_column("CategoryID")
-    code: Mapped[str] = mapped_column("Code")
-    is_default_item: Mapped[bool] = mapped_column("IsDefaultItem")
-    signature: Mapped[str] = mapped_column("Signature")
-    end_release_id: Mapped[int | None] = mapped_column("EndReleaseID")
-    row_guid: Mapped[uuid.UUID | None] = mapped_column(
-        "RowGUID",
-        ForeignKey(Concept.concept_guid),
-    )
-
-    __mapper_args__: ClassVar = {"primary_key": (row_guid,)}
-
-    unique_concept: Mapped[Concept | None] = relationship(foreign_keys=row_guid)
-
-
-class PSCurrentPropertyCategory(DPM):
-    """Auto-generated model for the PSCurrentPropertyCategory table."""
-
-    __tablename__ = "PSCurrentPropertyCategory"
-
-    property_id: Mapped[int] = mapped_column("PropertyID")
-    start_release_id: Mapped[int] = mapped_column("StartReleaseID")
-    category_id: Mapped[int] = mapped_column("CategoryID")
-    end_release_id: Mapped[int | None] = mapped_column("EndReleaseID")
-    row_guid: Mapped[uuid.UUID | None] = mapped_column(
-        "RowGUID",
-        ForeignKey(Concept.concept_guid),
-    )
-
-    __mapper_args__: ClassVar = {"primary_key": (row_guid,)}
-
-    unique_concept: Mapped[Concept | None] = relationship(foreign_keys=row_guid)
 
 
 class Release(DPM):
@@ -1241,6 +1122,60 @@ class OperationVersionData(DPM):
     )
 
 
+class PSCurrentItemCategory(DPM):
+    """Auto-generated model for the PSCurrentItemCategory table."""
+
+    __tablename__ = "PSCurrentItemCategory"
+
+    item_id: Mapped[int] = mapped_column("ItemID", ForeignKey(Item.item_id))
+    start_release_id: Mapped[int] = mapped_column("StartReleaseID")
+    category_id: Mapped[int] = mapped_column(
+        "CategoryID",
+        ForeignKey(Category.category_id),
+    )
+    code: Mapped[str] = mapped_column("Code")
+    is_default_item: Mapped[bool] = mapped_column("IsDefaultItem")
+    signature: Mapped[str] = mapped_column("Signature")
+    end_release_id: Mapped[int | None] = mapped_column("EndReleaseID")
+    row_guid: Mapped[uuid.UUID | None] = mapped_column(
+        "RowGUID",
+        ForeignKey(Concept.concept_guid),
+    )
+
+    __mapper_args__: ClassVar = {"primary_key": (row_guid,)}
+
+    item: Mapped[Item] = relationship(foreign_keys=item_id)
+    category: Mapped[Category] = relationship(foreign_keys=category_id)
+    unique_concept: Mapped[Concept | None] = relationship(foreign_keys=row_guid)
+
+
+class PSCurrentPropertyCategory(DPM):
+    """Auto-generated model for the PSCurrentPropertyCategory table."""
+
+    __tablename__ = "PSCurrentPropertyCategory"
+
+    property_id: Mapped[int] = mapped_column(
+        "PropertyID",
+        ForeignKey(Property.property_id),
+    )
+    start_release_id: Mapped[int] = mapped_column("StartReleaseID")
+    category_id: Mapped[int] = mapped_column(
+        "CategoryID",
+        ForeignKey(Category.category_id),
+    )
+    end_release_id: Mapped[int | None] = mapped_column("EndReleaseID")
+    row_guid: Mapped[uuid.UUID | None] = mapped_column(
+        "RowGUID",
+        ForeignKey(Concept.concept_guid),
+    )
+
+    __mapper_args__: ClassVar = {"primary_key": (row_guid,)}
+
+    property: Mapped[Property] = relationship(foreign_keys=property_id)
+    category: Mapped[Category] = relationship(foreign_keys=category_id)
+    unique_concept: Mapped[Concept | None] = relationship(foreign_keys=row_guid)
+
+
 class PropertyCategory(DPM):
     """Auto-generated model for the PropertyCategory table."""
 
@@ -1491,6 +1426,35 @@ class VariableCalculation(DPM):
     unique_concept: Mapped[Concept] = relationship(foreign_keys=row_guid)
 
 
+class AuxCellStatus(DPM):
+    """Auto-generated model for the Aux_CellStatus table."""
+
+    __tablename__ = "Aux_CellStatus"
+
+    table_vid: Mapped[int] = mapped_column(
+        "TableVID",
+        ForeignKey(TableVersion.table_vid),
+        primary_key=True,
+    )
+    cell_id: Mapped[int] = mapped_column(
+        "CellID",
+        ForeignKey(Cell.cell_id),
+        primary_key=True,
+    )
+    status: Mapped[
+        Literal[
+            "New variable",
+            "New variable version",
+            "Not reportable",
+            "Previous variable version",
+        ]
+    ] = mapped_column("Status")
+    is_new_cell: Mapped[bool] = mapped_column("IsNewCell")
+
+    table_version: Mapped[TableVersion] = relationship(foreign_keys=table_vid)
+    cell: Mapped[Cell] = relationship(foreign_keys=cell_id)
+
+
 class ModuleVersionComposition(DPM):
     """Auto-generated model for the ModuleVersionComposition table."""
 
@@ -1696,6 +1660,35 @@ class TableAssociation(DPM):
     )
     unique_concept: Mapped[Concept] = relationship(foreign_keys=row_guid)
     owner: Mapped[Organisation] = relationship(foreign_keys=owner_id)
+
+
+VarGenerationDetail = AlchemyTable(
+    "VarGeneration_Detail",
+    DPM.metadata,
+    Column("noofcells", Integer, nullable=False),
+    Column("NewAspect", String(255), nullable=False),
+    Column("ModuleVID", Integer, nullable=False),
+    Column("ModuleCode", String(255), nullable=False),
+    Column("TableCode", String(255), nullable=False),
+    Column("TableVID", Integer, nullable=False),
+    Column("CellID", Integer, nullable=False),
+    Column("cellcode", String(255), nullable=False),
+    Column("outcomeID", String(255), nullable=False),
+    Column("outcomeVID", String(255), nullable=False),
+    Column("ReportMsg", String(255), nullable=False),
+    Column("isVoid", Boolean, nullable=False),
+    Column("tvstartReleaseID", Integer, nullable=False),
+    Column("mvStartReleaseID", Integer, nullable=False),
+    Column("vvOldEndReleaseID", Integer, nullable=True),
+    Column("OldAspect", String(255), nullable=False),
+    Column("IsNewCell", Boolean, nullable=False),
+    Column("isnewPropertyDataType", Boolean, nullable=False),
+    Column("isNewKey", Boolean, nullable=False),
+    Column("OldVariableID", Integer, nullable=True),
+    Column("NewVarID", Integer, nullable=False),
+    Column("OldVariableVID", Integer, nullable=True),
+    Column("NewVVID", Integer, nullable=False),
+)
 
 
 class KeyHeaderMapping(DPM):
@@ -1990,6 +1983,39 @@ class TableVersionCell(DPM):
         foreign_keys=variable_vid,
     )
     unique_concept: Mapped[Concept] = relationship(foreign_keys=row_guid)
+
+
+ModelViolations = AlchemyTable(
+    "ModelViolations",
+    DPM.metadata,
+    Column("ViolationCode", String(255), nullable=False),
+    Column("Violation", String(255), nullable=False),
+    Column("isBlocking", Boolean, nullable=False),
+    Column("TableVID", Integer, nullable=False),
+    Column("OldTableVID", Integer, nullable=False),
+    Column("TableCode", String(255), nullable=False),
+    Column("HeaderID", Integer, nullable=False),
+    Column("HeaderCode", String(255), nullable=False),
+    Column("HeaderVID", Integer, nullable=False),
+    Column("OldHeaderVID", Integer, nullable=False),
+    Column("KeyHeader", Integer, nullable=False),
+    Column("HeaderDirection", String(255), nullable=False),
+    Column("HeaderPropertyID", Integer, nullable=False),
+    Column("HeaderPropertyCode", String(255), nullable=False),
+    Column("HeaderSubcategoryID", Integer, nullable=False),
+    Column("HeaderSubcategoryName", String(255), nullable=False),
+    Column("HeaderContextID", Integer, nullable=False),
+    Column("CategoryID", Integer, nullable=False),
+    Column("CategoryCode", String(255), nullable=False),
+    Column("ItemID", Integer, nullable=False),
+    Column("ItemCode", String(255), nullable=False),
+    Column("CellID", Integer, nullable=False),
+    Column("CellCode", String(255), nullable=False),
+    Column("Cell2ID", Integer, nullable=False),
+    Column("Cell2Code", String(255), nullable=False),
+    Column("VVEndReleaseID", Integer, nullable=False),
+    Column("NewAspect", String(255), nullable=False),
+)
 
 
 class TableVersionHeader(DPM):

--- a/projects/dpm2/src/dpm2/models.py
+++ b/projects/dpm2/src/dpm2/models.py
@@ -43,24 +43,6 @@ class AuxCellMapping(DPM):
     old_table_vid: Mapped[int] = mapped_column("OldTableVID")
 
 
-class AuxCellStatus(DPM):
-    """Auto-generated model for the Aux_CellStatus table."""
-
-    __tablename__ = "Aux_CellStatus"
-
-    table_vid: Mapped[int] = mapped_column("TableVID", primary_key=True)
-    cell_id: Mapped[int] = mapped_column("CellID", primary_key=True)
-    status: Mapped[
-        Literal[
-            "New variable",
-            "New variable version",
-            "Not reportable",
-            "Previous variable version",
-        ]
-    ] = mapped_column("Status")
-    is_new_cell: Mapped[bool] = mapped_column("IsNewCell")
-
-
 class Concept(DPM):
     """Auto-generated model for the Concept table."""
 
@@ -118,39 +100,6 @@ class Language(DPM):
 
     name: Mapped[str] = mapped_column("Name")
     language_code: Mapped[int] = mapped_column("LanguageCode", primary_key=True)
-
-
-ModelViolations = AlchemyTable(
-    "ModelViolations",
-    DPM.metadata,
-    Column("ViolationCode", String(255), nullable=False),
-    Column("Violation", String(255), nullable=False),
-    Column("isBlocking", Boolean, nullable=False),
-    Column("TableVID", Integer, nullable=True),
-    Column("OldTableVID", Integer, nullable=True),
-    Column("TableCode", String(255), nullable=True),
-    Column("HeaderID", Integer, nullable=True),
-    Column("HeaderCode", String(255), nullable=True),
-    Column("HeaderVID", Integer, nullable=True),
-    Column("OldHeaderVID", Integer, nullable=True),
-    Column("KeyHeader", Boolean, nullable=False),
-    Column("HeaderDirection", Enum("X"), nullable=True),
-    Column("HeaderPropertyID", Integer, nullable=False),
-    Column("HeaderPropertyCode", String(255), nullable=True),
-    Column("HeaderSubcategoryID", Integer, nullable=True),
-    Column("HeaderSubcategoryName", String(255), nullable=True),
-    Column("HeaderContextID", Integer, nullable=True),
-    Column("CategoryID", Integer, nullable=True),
-    Column("CategoryCode", String(255), nullable=True),
-    Column("ItemID", Integer, nullable=True),
-    Column("ItemCode", String(255), nullable=True),
-    Column("CellID", Integer, nullable=True),
-    Column("CellCode", String(255), nullable=True),
-    Column("Cell2ID", Integer, nullable=True),
-    Column("Cell2Code", String(255), nullable=True),
-    Column("VVEndReleaseID", Integer, nullable=True),
-    Column("NewAspect", String(255), nullable=True),
-)
 
 
 class Operator(DPM):
@@ -215,33 +164,6 @@ class SubdivisionType(DPM):
     )
 
 
-VarGenerationDetail = AlchemyTable(
-    "VarGeneration_Detail",
-    DPM.metadata,
-    Column("noofcells", Integer, nullable=False),
-    Column("NewAspect", String(255), nullable=False),
-    Column("ModuleVID", Integer, nullable=False),
-    Column("ModuleCode", String(255), nullable=False),
-    Column("TableCode", String(255), nullable=False),
-    Column("TableVID", Integer, nullable=False),
-    Column("CellID", Integer, nullable=False),
-    Column("cellcode", String(255), nullable=False),
-    Column("outcomeID", String(255), nullable=False),
-    Column("outcomeVID", String(255), nullable=False),
-    Column("ReportMsg", String(255), nullable=False),
-    Column("isVoid", Boolean, nullable=False),
-    Column("tvstartReleaseID", Integer, nullable=False),
-    Column("mvStartReleaseID", Integer, nullable=False),
-    Column("vvOldEndReleaseID", Integer, nullable=True),
-    Column("OldAspect", String(255), nullable=False),
-    Column("IsNewCell", Boolean, nullable=False),
-    Column("isnewPropertyDataType", Boolean, nullable=False),
-    Column("isNewKey", Boolean, nullable=False),
-    Column("OldVariableID", Integer, nullable=True),
-    Column("NewVarID", Integer, nullable=False),
-    Column("OldVariableVID", Integer, nullable=True),
-    Column("NewVVID", Integer, nullable=False),
-)
 VarGenerationSummary = AlchemyTable(
     "VarGeneration_Summary",
     DPM.metadata,
@@ -1441,6 +1363,35 @@ class VariableCalculation(DPM):
     unique_concept: Mapped[Concept] = relationship(foreign_keys=row_guid)
 
 
+class AuxCellStatus(DPM):
+    """Auto-generated model for the Aux_CellStatus table."""
+
+    __tablename__ = "Aux_CellStatus"
+
+    table_vid: Mapped[int] = mapped_column(
+        "TableVID",
+        ForeignKey(TableVersion.table_vid),
+        primary_key=True,
+    )
+    cell_id: Mapped[int] = mapped_column(
+        "CellID",
+        ForeignKey(Cell.cell_id),
+        primary_key=True,
+    )
+    status: Mapped[
+        Literal[
+            "New variable",
+            "New variable version",
+            "Not reportable",
+            "Previous variable version",
+        ]
+    ] = mapped_column("Status")
+    is_new_cell: Mapped[bool] = mapped_column("IsNewCell")
+
+    table_version: Mapped[TableVersion] = relationship(foreign_keys=table_vid)
+    cell: Mapped[Cell] = relationship(foreign_keys=cell_id)
+
+
 class ModuleVersionComposition(DPM):
     """Auto-generated model for the ModuleVersionComposition table."""
 
@@ -1646,6 +1597,35 @@ class TableAssociation(DPM):
     )
     unique_concept: Mapped[Concept] = relationship(foreign_keys=row_guid)
     owner: Mapped[Organisation] = relationship(foreign_keys=owner_id)
+
+
+VarGenerationDetail = AlchemyTable(
+    "VarGeneration_Detail",
+    DPM.metadata,
+    Column("noofcells", Integer, nullable=False),
+    Column("NewAspect", String(255), nullable=False),
+    Column("ModuleVID", Integer, nullable=False),
+    Column("ModuleCode", String(255), nullable=False),
+    Column("TableCode", String(255), nullable=False),
+    Column("TableVID", Integer, nullable=False),
+    Column("CellID", Integer, nullable=False),
+    Column("cellcode", String(255), nullable=False),
+    Column("outcomeID", String(255), nullable=False),
+    Column("outcomeVID", String(255), nullable=False),
+    Column("ReportMsg", String(255), nullable=False),
+    Column("isVoid", Boolean, nullable=False),
+    Column("tvstartReleaseID", Integer, nullable=False),
+    Column("mvStartReleaseID", Integer, nullable=False),
+    Column("vvOldEndReleaseID", Integer, nullable=True),
+    Column("OldAspect", String(255), nullable=False),
+    Column("IsNewCell", Boolean, nullable=False),
+    Column("isnewPropertyDataType", Boolean, nullable=False),
+    Column("isNewKey", Boolean, nullable=False),
+    Column("OldVariableID", Integer, nullable=True),
+    Column("NewVarID", Integer, nullable=False),
+    Column("OldVariableVID", Integer, nullable=True),
+    Column("NewVVID", Integer, nullable=False),
+)
 
 
 class KeyHeaderMapping(DPM):
@@ -1940,6 +1920,39 @@ class TableVersionCell(DPM):
         foreign_keys=variable_vid,
     )
     unique_concept: Mapped[Concept] = relationship(foreign_keys=row_guid)
+
+
+ModelViolations = AlchemyTable(
+    "ModelViolations",
+    DPM.metadata,
+    Column("ViolationCode", String(255), nullable=False),
+    Column("Violation", String(255), nullable=False),
+    Column("isBlocking", Boolean, nullable=False),
+    Column("TableVID", Integer, nullable=True),
+    Column("OldTableVID", Integer, nullable=True),
+    Column("TableCode", String(255), nullable=True),
+    Column("HeaderID", Integer, nullable=True),
+    Column("HeaderCode", String(255), nullable=True),
+    Column("HeaderVID", Integer, nullable=True),
+    Column("OldHeaderVID", Integer, nullable=True),
+    Column("KeyHeader", Boolean, nullable=False),
+    Column("HeaderDirection", Enum("X"), nullable=True),
+    Column("HeaderPropertyID", Integer, nullable=False),
+    Column("HeaderPropertyCode", String(255), nullable=True),
+    Column("HeaderSubcategoryID", Integer, nullable=True),
+    Column("HeaderSubcategoryName", String(255), nullable=True),
+    Column("HeaderContextID", Integer, nullable=True),
+    Column("CategoryID", Integer, nullable=True),
+    Column("CategoryCode", String(255), nullable=True),
+    Column("ItemID", Integer, nullable=True),
+    Column("ItemCode", String(255), nullable=True),
+    Column("CellID", Integer, nullable=True),
+    Column("CellCode", String(255), nullable=True),
+    Column("Cell2ID", Integer, nullable=True),
+    Column("Cell2Code", String(255), nullable=True),
+    Column("VVEndReleaseID", Integer, nullable=True),
+    Column("NewAspect", String(255), nullable=True),
+)
 
 
 class TableVersionHeader(DPM):

--- a/projects/migrate/src/migrate/processing.py
+++ b/projects/migrate/src/migrate/processing.py
@@ -18,6 +18,7 @@ from sqlalchemy.schema import CheckConstraint
 from migrate.transformations import (
     Rows,
     add_foreign_keys_to_table,
+    heal_cross_table_foreign_keys,
     parse_rows,
 )
 
@@ -87,6 +88,8 @@ def schema_and_data(access_database: Engine) -> tuple[MetaData, TablesWithRows]:
 
             if rows_list:
                 tables_with_rows.append((table, rows_list))
+
+    heal_cross_table_foreign_keys(schema)
 
     return schema, tables_with_rows
 

--- a/projects/migrate/src/migrate/transformations.py
+++ b/projects/migrate/src/migrate/transformations.py
@@ -87,6 +87,46 @@ def add_foreign_keys_to_table(table: Table) -> None:
     add_foreign_key_to_table(table, "GroupOperID", "Operation.OperationID")
 
 
+def _pick_canonical_owner(
+    owners: list[tuple[Table, Column[Any]]],
+) -> tuple[Table, Column[Any]] | None:
+    """Choose one table as the canonical FK target for a shared PK name.
+
+    When several tables share a single-column PK (e.g. ``OperationVID``
+    appears on both ``OperationVersion`` and ``OperationVersionData``),
+    the shorter table whose name prefixes the others is treated as the
+    owner; the longer names are auxiliary extensions that point at it.
+    If no single name prefixes every candidate, the PK stays ambiguous.
+    """
+    names = [table.name for table, _ in owners]
+    prefixes = [
+        (table, column)
+        for table, column in owners
+        if all(other.startswith(table.name) for other in names)
+    ]
+    if len(prefixes) == 1:
+        return prefixes[0]
+    return None
+
+
+def _resolve_pk_targets(
+    schema: MetaData,
+) -> dict[str, tuple[Table, Column[Any]]]:
+    """Map each usable single-column PK name to its canonical (table, col)."""
+    pk_owners: dict[str, list[tuple[Table, Column[Any]]]] = defaultdict(list)
+    for table in schema.tables.values():
+        pk_cols = list(table.primary_key.columns)
+        if len(pk_cols) == 1:
+            pk_owners[pk_cols[0].name].append((table, pk_cols[0]))
+
+    targets: dict[str, tuple[Table, Column[Any]]] = {}
+    for pk_name, owners in pk_owners.items():
+        canonical = owners[0] if len(owners) == 1 else _pick_canonical_owner(owners)
+        if canonical is not None:
+            targets[pk_name] = canonical
+    return targets
+
+
 def heal_cross_table_foreign_keys(schema: MetaData) -> None:
     """Link columns that share a name with another table's single-column PK.
 
@@ -95,24 +135,19 @@ def heal_cross_table_foreign_keys(schema: MetaData) -> None:
     ``ChangeLog.ActionID``). The DPM schema uses globally unique PK names
     (``ItemID``, ``ContextID``, ``AttributeID``...), so whenever a PK name
     identifies exactly one table we can safely link same-named columns to
-    it. PK names shared across tables (e.g. ``OperationVID`` appears on
-    both ``OperationVersion`` and ``OperationVersionData``) stay untouched.
+    it. When several tables share a PK name, ``_pick_canonical_owner``
+    resolves the ambiguity for the prefix case (``OperationVID`` →
+    ``OperationVersion``, not ``OperationVersionData``). The
+    ``target_table is table`` guard below prevents the canonical table's
+    own PK column from being linked back to itself.
     """
-    pk_owners: dict[str, list[tuple[Table, Column[Any]]]] = defaultdict(list)
-    for table in schema.tables.values():
-        pk_cols = list(table.primary_key.columns)
-        if len(pk_cols) == 1:
-            pk_owners[pk_cols[0].name].append((table, pk_cols[0]))
-
-    unique_targets = {
-        pk_name: owners[0] for pk_name, owners in pk_owners.items() if len(owners) == 1
-    }
+    targets = _resolve_pk_targets(schema)
 
     for table in schema.tables.values():
         for column in table.columns:
             if column.foreign_keys:
                 continue
-            target = unique_targets.get(column.name)
+            target = targets.get(column.name)
             if target is None:
                 continue
             target_table, target_column = target

--- a/projects/migrate/src/migrate/transformations.py
+++ b/projects/migrate/src/migrate/transformations.py
@@ -153,6 +153,4 @@ def heal_cross_table_foreign_keys(schema: MetaData) -> None:
             target_table, target_column = target
             if target_table is table:
                 continue
-            column.append_foreign_key(
-                ForeignKey(f"{target_table.name}.{target_column.name}"),
-            )
+            column.append_foreign_key(ForeignKey(target_column))

--- a/projects/migrate/src/migrate/transformations.py
+++ b/projects/migrate/src/migrate/transformations.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from typing import Any
 
 from schema.type_registry import enum_candidate
-from sqlalchemy import Column, ForeignKey, Row, Table
+from sqlalchemy import Column, ForeignKey, MetaData, Row, Table
 
 type Row_ = dict[str, Any]
 type Rows = list[Row_]
@@ -85,3 +85,39 @@ def add_foreign_keys_to_table(table: Table) -> None:
     # GroupOperID uses a truncated name (OperID ≠ OperationID), so the
     # ends-with-PK heuristic above cannot detect it automatically.
     add_foreign_key_to_table(table, "GroupOperID", "Operation.OperationID")
+
+
+def heal_cross_table_foreign_keys(schema: MetaData) -> None:
+    """Link columns that share a name with another table's single-column PK.
+
+    Some source releases ship tables whose FK constraints were dropped or
+    never declared (e.g. 4.3-draft lost ``ChangeLogAttribute.ActionID`` →
+    ``ChangeLog.ActionID``). The DPM schema uses globally unique PK names
+    (``ItemID``, ``ContextID``, ``AttributeID``...), so whenever a PK name
+    identifies exactly one table we can safely link same-named columns to
+    it. PK names shared across tables (e.g. ``OperationVID`` appears on
+    both ``OperationVersion`` and ``OperationVersionData``) stay untouched.
+    """
+    pk_owners: dict[str, list[tuple[Table, Column[Any]]]] = defaultdict(list)
+    for table in schema.tables.values():
+        pk_cols = list(table.primary_key.columns)
+        if len(pk_cols) == 1:
+            pk_owners[pk_cols[0].name].append((table, pk_cols[0]))
+
+    unique_targets = {
+        pk_name: owners[0] for pk_name, owners in pk_owners.items() if len(owners) == 1
+    }
+
+    for table in schema.tables.values():
+        for column in table.columns:
+            if column.foreign_keys:
+                continue
+            target = unique_targets.get(column.name)
+            if target is None:
+                continue
+            target_table, target_column = target
+            if target_table is table:
+                continue
+            column.append_foreign_key(
+                ForeignKey(f"{target_table.name}.{target_column.name}"),
+            )

--- a/projects/migrate/src/migrate/transformations.py
+++ b/projects/migrate/src/migrate/transformations.py
@@ -92,22 +92,22 @@ def _pick_canonical_owner(
 ) -> tuple[Table, Column[Any]] | None:
     """Choose one table as the canonical FK target for a PK name.
 
-    A single-owner list wins outright. When several tables share a
-    single-column PK (e.g. ``OperationVID`` appears on both
-    ``OperationVersion`` and ``OperationVersionData``), the shorter
-    table whose name prefixes the others is treated as the owner; the
-    longer names are auxiliary extensions that point at it. If no
-    single name prefixes every candidate, the PK stays ambiguous.
+    Every candidate whose name prefixes *every* candidate's name is a
+    valid owner: a single-owner list qualifies its lone entry (the
+    name trivially prefixes itself); a group like ``OperationVersion``
+    and ``OperationVersionData`` picks ``OperationVersion``. The
+    accumulator returns early when a second qualifying candidate
+    appears — that is the ambiguous case where no unique prefix wins.
     """
-    if len(owners) == 1:
-        return owners[0]
     names = [table.name for table, _ in owners]
-    prefixes = [
-        (table, column)
-        for table, column in owners
-        if all(other.startswith(table.name) for other in names)
-    ]
-    return prefixes[0] if len(prefixes) == 1 else None
+    winner: tuple[Table, Column[Any]] | None = None
+    for candidate in owners:
+        if not all(name.startswith(candidate[0].name) for name in names):
+            continue
+        if winner is not None:
+            return None
+        winner = candidate
+    return winner
 
 
 def _resolve_pk_targets(
@@ -116,8 +116,9 @@ def _resolve_pk_targets(
     """Map each usable single-column PK name to its canonical (table, col)."""
     pk_owners: dict[str, list[tuple[Table, Column[Any]]]] = defaultdict(list)
     for table in schema.tables.values():
-        if len(pk_cols := list(table.primary_key.columns)) == 1:
-            pk_owners[pk_cols[0].name].append((table, pk_cols[0]))
+        match list(table.primary_key.columns):
+            case [pk]:
+                pk_owners[pk.name].append((table, pk))
 
     return {
         pk_name: canonical
@@ -136,19 +137,18 @@ def heal_cross_table_foreign_keys(schema: MetaData) -> None:
     identifies exactly one table we can safely link same-named columns to
     it. When several tables share a PK name, ``_pick_canonical_owner``
     resolves the ambiguity for the prefix case (``OperationVID`` →
-    ``OperationVersion``, not ``OperationVersionData``). The
-    ``target_table is table`` guard below prevents the canonical table's
-    own PK column from being linked back to itself.
+    ``OperationVersion``, not ``OperationVersionData``). The comprehension
+    filter skips columns that already carry an FK and any self-reference
+    from the canonical table's own PK column.
     """
     targets = _resolve_pk_targets(schema)
-
-    for table in schema.tables.values():
-        for column in table.columns:
-            if column.foreign_keys:
-                continue
-            if (target := targets.get(column.name)) is None:
-                continue
-            target_table, target_column = target
-            if target_table is table:
-                continue
-            column.append_foreign_key(ForeignKey(target_column))
+    fresh_fks = [
+        (column, target[1])
+        for table in schema.tables.values()
+        for column in table.columns
+        if not column.foreign_keys
+        and (target := targets.get(column.name)) is not None
+        and target[0] is not table
+    ]
+    for column, target_column in fresh_fks:
+        column.append_foreign_key(ForeignKey(target_column))

--- a/projects/migrate/src/migrate/transformations.py
+++ b/projects/migrate/src/migrate/transformations.py
@@ -90,23 +90,24 @@ def add_foreign_keys_to_table(table: Table) -> None:
 def _pick_canonical_owner(
     owners: list[tuple[Table, Column[Any]]],
 ) -> tuple[Table, Column[Any]] | None:
-    """Choose one table as the canonical FK target for a shared PK name.
+    """Choose one table as the canonical FK target for a PK name.
 
-    When several tables share a single-column PK (e.g. ``OperationVID``
-    appears on both ``OperationVersion`` and ``OperationVersionData``),
-    the shorter table whose name prefixes the others is treated as the
-    owner; the longer names are auxiliary extensions that point at it.
-    If no single name prefixes every candidate, the PK stays ambiguous.
+    A single-owner list wins outright. When several tables share a
+    single-column PK (e.g. ``OperationVID`` appears on both
+    ``OperationVersion`` and ``OperationVersionData``), the shorter
+    table whose name prefixes the others is treated as the owner; the
+    longer names are auxiliary extensions that point at it. If no
+    single name prefixes every candidate, the PK stays ambiguous.
     """
+    if len(owners) == 1:
+        return owners[0]
     names = [table.name for table, _ in owners]
     prefixes = [
         (table, column)
         for table, column in owners
         if all(other.startswith(table.name) for other in names)
     ]
-    if len(prefixes) == 1:
-        return prefixes[0]
-    return None
+    return prefixes[0] if len(prefixes) == 1 else None
 
 
 def _resolve_pk_targets(
@@ -115,16 +116,14 @@ def _resolve_pk_targets(
     """Map each usable single-column PK name to its canonical (table, col)."""
     pk_owners: dict[str, list[tuple[Table, Column[Any]]]] = defaultdict(list)
     for table in schema.tables.values():
-        pk_cols = list(table.primary_key.columns)
-        if len(pk_cols) == 1:
+        if len(pk_cols := list(table.primary_key.columns)) == 1:
             pk_owners[pk_cols[0].name].append((table, pk_cols[0]))
 
-    targets: dict[str, tuple[Table, Column[Any]]] = {}
-    for pk_name, owners in pk_owners.items():
-        canonical = owners[0] if len(owners) == 1 else _pick_canonical_owner(owners)
-        if canonical is not None:
-            targets[pk_name] = canonical
-    return targets
+    return {
+        pk_name: canonical
+        for pk_name, owners in pk_owners.items()
+        if (canonical := _pick_canonical_owner(owners)) is not None
+    }
 
 
 def heal_cross_table_foreign_keys(schema: MetaData) -> None:
@@ -147,8 +146,7 @@ def heal_cross_table_foreign_keys(schema: MetaData) -> None:
         for column in table.columns:
             if column.foreign_keys:
                 continue
-            target = targets.get(column.name)
-            if target is None:
+            if (target := targets.get(column.name)) is None:
                 continue
             target_table, target_column = target
             if target_table is table:

--- a/projects/migrate/tests/test_transformations.py
+++ b/projects/migrate/tests/test_transformations.py
@@ -37,11 +37,11 @@ def test_heal_links_columns_to_unique_pk_targets() -> None:
     assert ctx_fk.target_fullname == "Context.ContextID"
 
 
-def test_heal_skips_ambiguous_primary_key_names() -> None:
-    """Shared PK names across tables leave referring columns untouched."""
+def test_heal_prefers_prefix_named_table_as_canonical_owner() -> None:
+    """When one candidate name prefixes the others, it wins the FK target."""
     metadata = MetaData()
-    _single_pk_table(metadata, "OperationVersion", "OperationVID")
-    _single_pk_table(metadata, "OperationVersionData", "OperationVID")
+    canonical = _single_pk_table(metadata, "OperationVersion", "OperationVID")
+    extension = _single_pk_table(metadata, "OperationVersionData", "OperationVID")
     referrer = Table(
         "Referrer",
         metadata,
@@ -51,7 +51,28 @@ def test_heal_skips_ambiguous_primary_key_names() -> None:
 
     heal_cross_table_foreign_keys(metadata)
 
-    assert not referrer.columns["OperationVID"].foreign_keys
+    assert not canonical.columns["OperationVID"].foreign_keys
+    extension_fk = next(iter(extension.columns["OperationVID"].foreign_keys))
+    referrer_fk = next(iter(referrer.columns["OperationVID"].foreign_keys))
+    assert extension_fk.target_fullname == "OperationVersion.OperationVID"
+    assert referrer_fk.target_fullname == "OperationVersion.OperationVID"
+
+
+def test_heal_skips_unrelated_shared_primary_key_names() -> None:
+    """Shared PK names on unrelated tables leave referring columns alone."""
+    metadata = MetaData()
+    _single_pk_table(metadata, "Foo", "SharedID")
+    _single_pk_table(metadata, "Bar", "SharedID")
+    referrer = Table(
+        "Referrer",
+        metadata,
+        Column("ID", Integer, primary_key=True),
+        Column("SharedID", Integer),
+    )
+
+    heal_cross_table_foreign_keys(metadata)
+
+    assert not referrer.columns["SharedID"].foreign_keys
 
 
 def test_heal_does_not_self_reference() -> None:

--- a/projects/migrate/tests/test_transformations.py
+++ b/projects/migrate/tests/test_transformations.py
@@ -1,0 +1,85 @@
+"""Tests for migrate.transformations."""
+
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table
+
+from migrate.transformations import heal_cross_table_foreign_keys
+
+
+def _single_pk_table(metadata: MetaData, name: str, pk_column: str) -> Table:
+    """Create a minimal table with one single-column primary key for tests."""
+    return Table(
+        name,
+        metadata,
+        Column(pk_column, Integer, primary_key=True),
+        Column("Label", String),
+    )
+
+
+def test_heal_links_columns_to_unique_pk_targets() -> None:
+    """Columns named like a unique PK in another table gain that FK."""
+    metadata = MetaData()
+    _single_pk_table(metadata, "Item", "ItemID")
+    _single_pk_table(metadata, "Context", "ContextID")
+    _single_pk_table(metadata, "Release", "StartReleaseID")
+    compound = Table(
+        "CompoundItemContext",
+        metadata,
+        Column("ItemID", Integer, primary_key=True),
+        Column("StartReleaseID", Integer, primary_key=True),
+        Column("ContextID", Integer),
+    )
+
+    heal_cross_table_foreign_keys(metadata)
+
+    item_fk = next(iter(compound.columns["ItemID"].foreign_keys))
+    ctx_fk = next(iter(compound.columns["ContextID"].foreign_keys))
+    assert item_fk.target_fullname == "Item.ItemID"
+    assert ctx_fk.target_fullname == "Context.ContextID"
+
+
+def test_heal_skips_ambiguous_primary_key_names() -> None:
+    """Shared PK names across tables leave referring columns untouched."""
+    metadata = MetaData()
+    _single_pk_table(metadata, "OperationVersion", "OperationVID")
+    _single_pk_table(metadata, "OperationVersionData", "OperationVID")
+    referrer = Table(
+        "Referrer",
+        metadata,
+        Column("ID", Integer, primary_key=True),
+        Column("OperationVID", Integer),
+    )
+
+    heal_cross_table_foreign_keys(metadata)
+
+    assert not referrer.columns["OperationVID"].foreign_keys
+
+
+def test_heal_does_not_self_reference() -> None:
+    """A table's own PK column is never linked back to itself."""
+    metadata = MetaData()
+    item = Table(
+        "Item",
+        metadata,
+        Column("ItemID", Integer, primary_key=True),
+        Column("OtherID", Integer),
+    )
+
+    heal_cross_table_foreign_keys(metadata)
+
+    assert not item.columns["ItemID"].foreign_keys
+
+
+def test_heal_does_not_overwrite_declared_foreign_key() -> None:
+    """Columns that already carry an FK are not given a duplicate one."""
+    metadata = MetaData()
+    _single_pk_table(metadata, "Item", "ItemID")
+    other = Table(
+        "Other",
+        metadata,
+        Column("ID", Integer, primary_key=True),
+        Column("ItemID", Integer, ForeignKey("Item.ItemID")),
+    )
+
+    heal_cross_table_foreign_keys(metadata)
+
+    assert len(list(other.columns["ItemID"].foreign_keys)) == 1


### PR DESCRIPTION
## Summary
This PR adds automatic foreign key constraint detection and application to the DPM schema models. It introduces a new transformation function that intelligently links columns to their corresponding primary keys across tables, resolving missing FK declarations that exist in the source database.

## Key Changes

- **New `heal_cross_table_foreign_keys()` function** in `migrate/transformations.py`:
  - Automatically detects single-column primary keys across all tables in the schema
  - Links same-named columns to their canonical PK targets
  - Implements intelligent disambiguation when multiple tables share a PK name (e.g., `OperationVID` on both `OperationVersion` and `OperationVersionData`)
  - Uses a prefix-matching heuristic to identify canonical owners (shorter table names that prefix longer ones)
  - Prevents self-referential FKs and avoids overwriting existing FK declarations

- **Updated model definitions** in `dpm2/models.py`:
  - `AuxCellStatus`: Added ForeignKey constraints to `TableVersion.table_vid` and `Cell.cell_id`, plus corresponding relationships
  - `PSCurrentItemCategory`: Added ForeignKey constraints to `Item.item_id` and `Category.category_id`, plus corresponding relationships
  - `PSCurrentPropertyCategory`: Added ForeignKey constraints to `Property.property_id` and `Category.category_id`, plus corresponding relationships
  - Reorganized class definitions to maintain logical grouping (moved classes to appear after their FK targets are defined)

- **Integration** in `migrate/processing.py`:
  - Integrated `heal_cross_table_foreign_keys()` into the schema processing pipeline

- **Comprehensive test suite** in `migrate/tests/test_transformations.py`:
  - Tests for basic FK linking by column name matching
  - Tests for prefix-based canonical owner selection
  - Tests for skipping ambiguous shared PK names
  - Tests for preventing self-references
  - Tests for preserving existing FK declarations

## Implementation Details

The `_pick_canonical_owner()` function resolves ambiguity by selecting the table whose name is a prefix of all other candidates. This handles the common DPM pattern where extension tables (e.g., `OperationVersionData`) extend a base table (e.g., `OperationVersion`) with the same PK name.

The healing process is conservative: it only creates FKs when there's a clear, unambiguous target, and it never overwrites existing FK declarations.

https://claude.ai/code/session_01Rhm4qJx2LkSTCGh3VxqFRm