### PR TITLE
Add 4.3-release to version archive

### DIFF
--- a/projects/archive/src/archive/versions.toml
+++ b/projects/archive/src/archive/versions.toml
@@ -156,3 +156,12 @@ date = 2026-04-16
 original = { url = "https://www.eba.europa.eu/sites/default/files/2026-04/a0cbe984-bb81-4546-bb27-a1cb87b8603a/DPM2%20Database_v4.3_draft.accdb_.zip", checksum = "sha256:edb25fb5273c4a4728028c33ec542fadbdb12bcc9b764ba22e067fdd022325ba" }
 archive = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.3-draft/dpm-4.3-draft-archive.zip", checksum = "sha256:672eebacfee9674e1891dc0efab8db5d6bdd964f31ae14c88c66ebf8852111e2" }
 converted = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.3-draft/dpm-4.3-draft-sqlite.zip", checksum = "sha256:07544a35b5c73f1122b928c13d1848931ea812894043068e3066d03a23d85a46" }
+
+[[versions]]
+id = "4.3-release"
+previous = "4.3-draft"
+version = "4.3"
+type = "release"
+semver = "4.3.0"
+date = 2026-07-09
+original = { url = "https://ebprstaewspublic01.blob.core.windows.net/public/tools-prod/documents/Big_Files/files/Reporting%20framework%204.3/DPM2%20Database_v%204_3.zip", checksum = "sha256:77e2ba9ccb2ff3e598dc840caf4cfbe02941097ada239d59340389f481c0c9d1" }


### PR DESCRIPTION
Register the DPM 2.0 release 4.3 published by the EBA. The download is
hosted on the EBA public blob storage; per its Azure metadata the file
was uploaded on 2026-07-09 (Last-Modified / x-ms-creation-time
2026-07-09T09:22:02Z). Only the original source is populated; the
archive and converted sources will be added once the db-4.3-release
GitHub release is built. SHA256 checksum was computed locally against
the downloaded file.

https://www.eba.europa.eu/risk-and-data-analysis/reporting/reporting-frameworks/reporting-framework-43

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R2241EFdokeN5Vq2TiPQ57