### PR TITLE
Preserve DPM 4.3.0 and register 4.3.1 (in-place EBA overwrite)

### DIFF
--- a/.github/workflows/publish-archive.yml
+++ b/.github/workflows/publish-archive.yml
@@ -9,11 +9,14 @@ name: Publish Archive
 #
 # Source selection:
 #   * Default: re-download the original from the URL registered in
-#     versions.toml for <version_id>.
-#   * source_run_id set: pull the already-downloaded archive artifact from a
-#     previous build run instead of downloading. Use this when the upstream
-#     file has been overwritten in place (the URL now serves a different
-#     version), so a fresh download would fetch the wrong bytes.
+#     versions.toml for <version_id> and publish the archive only.
+#   * source_run_id set: pull the already-downloaded '<version_id>-archive'
+#     artifact (and, if present, the '<version_id>-archive-sqlite' converted
+#     database) from a previous build run instead of downloading. Use this
+#     when the upstream file has been overwritten in place (the URL now serves
+#     a different version), so a fresh download would fetch the wrong bytes.
+#     The prebuilt SQLite is attached too, since it cannot be reproduced once
+#     the source URL no longer serves the original bytes.
 
 on:
   workflow_dispatch:
@@ -57,6 +60,18 @@ jobs:
           run-id: ${{ inputs.source_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # The converted SQLite is a prebuilt byproduct of the same run; attach it
+      # when present. Best-effort: a run without it still publishes the archive.
+      - name: Download converted SQLite from existing run
+        if: inputs.source_run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.version_id }}-archive-sqlite
+          path: converted-files/
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # --- Source B: fresh download from the registered source URL ---------
       - name: Install UV
         if: inputs.source_run_id == ''
@@ -84,6 +99,12 @@ jobs:
           cd archive-files
           zip -r "../dpm-${VERSION_ID}-archive.zip" .
 
+      - name: Create SQLite zip
+        if: hashFiles('converted-files/**/*.sqlite') != ''
+        run: |
+          cd converted-files
+          zip "../dpm-${VERSION_ID}-sqlite.zip" *.sqlite
+
       - name: Create or update GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -94,5 +115,6 @@ jobs:
 
             **Available Downloads:**
             - `dpm-${{ env.VERSION_ID }}-archive.zip` - Original Access database files
+            - `dpm-${{ env.VERSION_ID }}-sqlite.zip` - Converted SQLite database (when available)
           prerelease: ${{ inputs.prerelease }}
-          files: dpm-${{ env.VERSION_ID }}-archive.zip
+          files: dpm-${{ env.VERSION_ID }}-*.zip

--- a/.github/workflows/publish-archive.yml
+++ b/.github/workflows/publish-archive.yml
@@ -1,0 +1,98 @@
+name: Publish Archive
+
+# Publishes ONLY the archive (original Access database files) to the
+# db-<version_id> GitHub release.
+#
+# Deliberately decoupled from the Windows migration/analysis steps in
+# publish-database-files.yml: preserving the source database must never be
+# blocked by a migration failure.
+#
+# Source selection:
+#   * Default: re-download the original from the URL registered in
+#     versions.toml for <version_id>.
+#   * source_run_id set: pull the already-downloaded archive artifact from a
+#     previous build run instead of downloading. Use this when the upstream
+#     file has been overwritten in place (the URL now serves a different
+#     version), so a fresh download would fetch the wrong bytes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_id:
+        description: "Database version to publish (e.g., 4.3-release)"
+        required: true
+        type: string
+      source_run_id:
+        description: "Optional: a previous run whose '<version_id>-archive' artifact holds the correct files. Use when the upstream URL has been overwritten in place."
+        required: false
+        type: string
+        default: ""
+      prerelease:
+        description: "Mark as prerelease"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  VERSION_ID: ${{ inputs.version_id }}
+
+jobs:
+  publish-archive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read # required to download artifacts from another run
+    steps:
+      - uses: actions/checkout@v7
+
+      # --- Source A: reuse the archive artifact from an existing run -------
+      # build-database.yml names this artifact '<version_id>-archive' even when
+      # it falls back to the original source, so it holds the original files.
+      - name: Download archive from existing run
+        if: inputs.source_run_id != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.version_id }}-archive
+          path: archive-files/
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Source B: fresh download from the registered source URL ---------
+      - name: Install UV
+        if: inputs.source_run_id == ''
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        if: inputs.source_run_id == ''
+        run: uv python install
+
+      - name: Install dependencies
+        if: inputs.source_run_id == ''
+        run: uv sync
+
+      - name: Download original from source
+        if: inputs.source_run_id == ''
+        run: |
+          set -eo pipefail
+          uv run dpm-toolkit download "$VERSION_ID" --variant original > /tmp/original.zip
+          unzip /tmp/original.zip -d archive-files/
+          rm -f /tmp/original.zip
+
+      # --- Package and publish --------------------------------------------
+      - name: Create archive zip
+        run: |
+          cd archive-files
+          zip -r "../dpm-${VERSION_ID}-archive.zip" .
+
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: db-${{ env.VERSION_ID }}
+          name: "DPM Database Files - ${{ env.VERSION_ID }}"
+          body: |
+            Database files for version ${{ env.VERSION_ID }}
+
+            **Available Downloads:**
+            - `dpm-${{ env.VERSION_ID }}-archive.zip` - Original Access database files
+          prerelease: ${{ inputs.prerelease }}
+          files: dpm-${{ env.VERSION_ID }}-archive.zip

--- a/projects/archive/src/archive/versions.toml
+++ b/projects/archive/src/archive/versions.toml
@@ -165,3 +165,13 @@ type = "release"
 semver = "4.3.0"
 date = 2026-07-09
 original = { url = "https://ebprstaewspublic01.blob.core.windows.net/public/tools-prod/documents/Big_Files/files/Reporting%20framework%204.3/DPM2%20Database_v%204_3.zip", checksum = "sha256:77e2ba9ccb2ff3e598dc840caf4cfbe02941097ada239d59340389f481c0c9d1" }
+
+[[versions]]
+id = "4.3-errata-1"
+previous = "4.3-release"
+version = "4.3"
+type = "errata"
+semver = "4.3.1"
+date = 2026-07-17
+revision = 1
+original = { url = "https://ebprstaewspublic01.blob.core.windows.net/public/tools-prod/documents/Big_Files/files/Reporting%20framework%204.3/DPM2%20Database_v%204_3.zip", checksum = "sha256:f2d802f1430879cf085d21e2279630d7a10e1207e2a100ab01188136cf0b2cac" }


### PR DESCRIPTION
## Background

The EBA reuses a stable blob URL for the 4.3 database and **overwrote it in place** on 2026-07-17, replacing DPM **4.3.0** with **4.3.1** without changing the URL. Our new-version detection (`compare_version_urls`) diffs only on the URL string, so the replacement went undetected. The EBA framework 4.3 page now labels that URL "DPM 4.3.1".

- `4.3-release` (semver 4.3.0, checksum `77e2ba9c…`) was correctly registered — it is the file hosted from 2026-07-09 until the overwrite.
- The same URL now serves different bytes (checksum `f2d802f1…`, Azure creation-time 2026-07-17), i.e. 4.3.1.

The genuine 4.3.0 bytes are **no longer downloadable** from the source, but CI downloaded them before the overwrite: run `29492570966` (2026-07-16, on `main`) holds `4.3-release-archive` (the original `.accdb`) and `4.3-release-archive-sqlite` (the converted DB), both expiring 2026-10-14. Verified: the recovered `.accdb` (`f961f31f…`) differs from the current 4.3.1 `.accdb` (`0def3144…`, renamed `..._20260622.accdb`).

## Changes

- **`versions.toml`**: add `4.3-errata-1` (semver `4.3.1`, checksum `f2d802f1…`) following the existing errata convention. The `4.3-release` (4.3.0) entry is unchanged.
- **`.github/workflows/publish-archive.yml`**: new `workflow_dispatch` action that publishes the archive (and prebuilt converted SQLite) to the `db-<version_id>` release, **decoupled from the Windows migration/analysis jobs** that gate `publish-database-files.yml`. It accepts an optional `source_run_id` to pull the already-downloaded artifacts from a prior run instead of re-downloading — needed here because a fresh download would now fetch 4.3.1.

## Follow-up after merge

1. Dispatch **Publish Archive** with `version_id=4.3-release`, `source_run_id=29492570966` to create the `db-4.3-release` release from the verified 4.3.0 artifact + SQLite (preserves 4.3.0 durably before the CI artifacts expire).
2. Fill in the `archive`/`converted` sources for `4.3-release` in `versions.toml` pointing at the new release assets.
3. Build/publish 4.3.1 (`4.3-errata-1`) from the current URL.
4. Consider hardening `compare_version_urls` to also track the original checksum so in-place overwrites are detected in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ak7AgTKfnK4J3StNwSgXa

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ak7AgTKfnK4J3StNwSgXa)_