### PR TITLE
Register archive + converted sources for 4.3-release (4.3.0)

### DIFF
--- a/projects/archive/src/archive/versions.toml
+++ b/projects/archive/src/archive/versions.toml
@@ -165,6 +165,8 @@ type = "release"
 semver = "4.3.0"
 date = 2026-07-09
 original = { url = "https://ebprstaewspublic01.blob.core.windows.net/public/tools-prod/documents/Big_Files/files/Reporting%20framework%204.3/DPM2%20Database_v%204_3.zip", checksum = "sha256:77e2ba9ccb2ff3e598dc840caf4cfbe02941097ada239d59340389f481c0c9d1" }
+archive = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.3-release/dpm-4.3-release-archive.zip", checksum = "sha256:eed05e942156ff46cf4d3a7b4f5120bc27ecdd223256c2f587cd0701e62df1e1" }
+converted = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.3-release/dpm-4.3-release-sqlite.zip", checksum = "sha256:3cdd3e9ac794af37cfd4280f5f3e4087cf090a79ee4f8eac6d1bab89a7fb7876" }
 
 [[versions]]
 id = "4.3-errata-1"


### PR DESCRIPTION
## Summary

Follow-up to #141. The `db-4.3-release` GitHub release has now been published from the preserved 4.3.0 artifacts (via the `publish-archive.yml` workflow, sourced from CI run `29492570966`). This registers its `archive` and `converted` sources in `versions.toml`, completing the `4.3-release` (semver 4.3.0) entry.

## Verification

- `dpm-4.3-release-archive.zip` — inner `DPM2 Database_v 4_3.accdb` hashes to `f961f31f…`, matching the recovered 4.3.0 database. Zip SHA256 `eed05e94…`.
- `dpm-4.3-release-sqlite.zip` — converted `4.3-release-archive.sqlite`. Zip SHA256 `3cdd3e9a…`.

Both zip checksums match the digests GitHub reports for the release assets.

## Context

The genuine 4.3.0 bytes are no longer downloadable from the EBA source (that URL was overwritten in place with 4.3.1 on 2026-07-17). These sources point at the durable GitHub release built from the pre-overwrite CI artifacts, so 4.3.0 remains available going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ak7AgTKfnK4J3StNwSgXa

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ak7AgTKfnK4J3StNwSgXa)_