### PR TITLE
Register archive + converted sources for 4.3-errata-1 (4.3.1)

### DIFF
--- a/projects/archive/src/archive/versions.toml
+++ b/projects/archive/src/archive/versions.toml
@@ -177,3 +177,5 @@ semver = "4.3.1"
 date = 2026-07-17
 revision = 1
 original = { url = "https://ebprstaewspublic01.blob.core.windows.net/public/tools-prod/documents/Big_Files/files/Reporting%20framework%204.3/DPM2%20Database_v%204_3.zip", checksum = "sha256:f2d802f1430879cf085d21e2279630d7a10e1207e2a100ab01188136cf0b2cac" }
+archive = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.3-errata-1/dpm-4.3-errata-1-archive.zip", checksum = "sha256:6d28ea2807aecb39823addf91eb9e42b4af5f2b53ebfeb15bedf3b70f25e3484" }
+converted = { url = "https://github.com/JimLundin/dpm-toolkit/releases/download/db-4.3-errata-1/dpm-4.3-errata-1-sqlite.zip", checksum = "sha256:f83fbdd2f387bc88b507f604b41cd1ce89707f55004ab59b01eb53d5fb1acea5" }


### PR DESCRIPTION
## Summary

Completes the 4.3.1 integration. The `db-4.3-errata-1` GitHub release was published via `publish-database-files.yml` (run `29683193640`, downloaded from the live EBA URL which now correctly serves 4.3.1, then migrated on Windows). This registers its `archive` and `converted` sources in `versions.toml`, completing the `4.3-errata-1` (semver 4.3.1) entry.

## Verification

- `dpm-4.3-errata-1-archive.zip` — inner `DPM2 Database_v 4_3_20260622.accdb` hashes to `0def3144…`, matching the current live 4.3.1 database. Zip SHA256 `6d28ea28…`.
- `dpm-4.3-errata-1-sqlite.zip` — converted SQLite. Zip SHA256 `f83fbdd2…`.

Both zip checksums match the digests GitHub reports for the release assets.

## State after merge

Both 4.3 point releases are now fully tracked with all three sources:

| id | semver | original | archive | converted |
|----|--------|----------|---------|-----------|
| `4.3-release` | 4.3.0 | ✓ | ✓ (db-4.3-release) | ✓ (db-4.3-release) |
| `4.3-errata-1` | 4.3.1 | ✓ | ✓ (db-4.3-errata-1) | ✓ (db-4.3-errata-1) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ak7AgTKfnK4J3StNwSgXa

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ak7AgTKfnK4J3StNwSgXa)_